### PR TITLE
Test: Add Unit Tests for OllamaFormatter (100% Coverage)

### DIFF
--- a/src/OllamaFormatter.test.ts
+++ b/src/OllamaFormatter.test.ts
@@ -1,0 +1,52 @@
+// src/OllamaFormatter.test.ts
+import { describe, it, expect } from 'vitest';
+import { OllamaFormatter } from './OllamaFormatter';
+import type { Message } from './PromptBuilder'; // Import the Message type
+
+describe('OllamaFormatter', () => {
+  it('should instantiate without errors', () => {
+    expect(() => new OllamaFormatter()).not.toThrow();
+  });
+
+  it('should return an object with an empty messages array when given an empty array', () => {
+    const formatter = new OllamaFormatter();
+    const messages: Message[] = [];
+    const result = formatter.format(messages);
+    expect(result).toEqual({ messages: [] });
+  });
+
+  it('should return an object with the same messages array that was passed in (single message)', () => {
+    const formatter = new OllamaFormatter();
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello, Ollama!' },
+    ];
+    const result = formatter.format(messages);
+    // We expect the 'messages' property in the result to be the same array instance,
+    // or at least deeply equal. Given the current implementation, it's the same instance.
+    expect(result).toEqual({ messages: messages });
+    // Optionally, to be very specific about the instance if that's a contract:
+    // expect(result.messages).toBe(messages);
+  });
+
+  it('should return an object with the same messages array that was passed in (multiple messages)', () => {
+    const formatter = new OllamaFormatter();
+    const messages: Message[] = [
+      { role: 'system', content: 'You are an assistant.' },
+      { role: 'user', content: 'Tell me a joke.' },
+      { role: 'assistant', content: 'Why did the chicken cross the road?' },
+    ];
+    const result = formatter.format(messages);
+    expect(result).toEqual({ messages: messages });
+  });
+
+  it('should return an object that only contains the messages key by default', () => {
+    const formatter = new OllamaFormatter();
+    const messages: Message[] = [
+      { role: 'user', content: 'Test message' },
+    ];
+    const result = formatter.format(messages);
+    expect(Object.keys(result)).toEqual(['messages']);
+    expect(result.model).toBeUndefined();
+    expect(result.stream).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR introduces unit tests for the `OllamaFormatter` class, achieving 100% code coverage for this component.

**Key Changes:**
- Created `src/OllamaFormatter.test.ts`.
- Implemented tests covering instantiation and the `format` method with various inputs (empty array, single message, multiple messages).
- Verified correct structure of the returned payload.

All tests are passing, and this ensures the reliability of the Ollama-specific formatting logic.

Closes #9 