### PR TITLE
Docs: Add CI Status Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @taleef/llm-prompt-kit
 
+[![Node.js CI](https://github.com/Taleef7/llm-prompt-kit/actions/workflows/node-ci.yml/badge.svg)](https://github.com/Taleef7/llm-prompt-kit/actions/workflows/node-ci.yml)
+
 A flexible and powerful toolkit for building, managing, and formatting prompts for Large Language Models (LLMs) in TypeScript/JavaScript projects.
 
 ## The Problem


### PR DESCRIPTION
Adds the workflow status badge for the Node.js CI pipeline to the README.

Closes #13 